### PR TITLE
Minor correction to instance exclusions

### DIFF
--- a/doc_source/ec2-recommendations.md
+++ b/doc_source/ec2-recommendations.md
@@ -141,8 +141,5 @@ Keep the following considerations in mind when generating EC2 instance recommend
   + Previous generation instances \(C3, for example\)
   + Bare Metal instances
   + ARM instances \(A1, for example\)
-  + Amazon EBS\-optimized instances
-  + GPU\-optimized instances \(P3, for example\)
-  + Network\-optimized instances
   + 32\-bit instances
 + If the operating system for a server is not supported by Amazon EC2, that server's returned recommendation will be `Linux`\. Additional information can be found in the `Recommendation.EC2.Remarks` column for each affected server\.


### PR DESCRIPTION

*Issue #, if available:* N/A

*Description of changes:*

Removing items from the list of instance types that are excluded from recommendations. The items I removed from the list are not excluded by default, although customers could choose to optionally exclude them from a particular export (as with any other instance type).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
